### PR TITLE
Add deploy environment MCP tool

### DIFF
--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -1,6 +1,7 @@
 import type { AbortEnvironmentParams } from '../mcp/schemas/abort-environment-schema';
 import type { ApproveEnvironmentParams } from '../mcp/schemas/approve-environment-schema';
 import type { CancelEnvironmentParams } from '../mcp/schemas/cancel-environment-schema';
+import type { DeployEnvironmentParams } from '../mcp/schemas/deploy-environment-schema';
 import type { GetEnvironmentsParams } from '../mcp/schemas/get-environments-params-schema';
 import type { Env0Config } from './env0-client';
 import type Env0Client from './env0-client';
@@ -81,6 +82,21 @@ export class Env0Service {
     return this.env0Client.request({
       url: `/mcp/environments/${environmentId}/abort`,
       method: 'POST'
+    });
+  }
+
+  async deployEnvironment({
+    environmentId,
+    revision,
+    comment
+  }: DeployEnvironmentParams): Promise<object> {
+    return this.env0Client.request({
+      url: `/mcp/environments/${environmentId}/deployments`,
+      method: 'POST',
+      data: {
+        revision,
+        comment
+      }
     });
   }
 }

--- a/src/env0-service/models/cloud-resource.d.ts
+++ b/src/env0-service/models/cloud-resource.d.ts
@@ -46,7 +46,7 @@ interface CloudResource {
   cloudId?: string;
 
   name?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 
   clickOpsCount: number;
   apiOpsCount: number;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -7,6 +7,7 @@ import { registerApproveEnvironmentTool } from './tools/approve-environment';
 import { registerCancelEnvironmentTool } from './tools/cancel-environment';
 import { registerAbortEnvironmentTool } from './tools/abort-environment';
 import { registerGetCloudResourcesTool } from './tools/get-cloud-resources';
+import { registerDeployEnvironmentTool } from './tools/deploy-environment';
 
 export function createMcpServer(env0Service: Env0Service): McpServer {
   const server = new McpServer({
@@ -21,6 +22,7 @@ export function createMcpServer(env0Service: Env0Service): McpServer {
   registerCancelEnvironmentTool(server, env0Service);
   registerAbortEnvironmentTool(server, env0Service);
   registerGetCloudResourcesTool(server, env0Service);
+  registerDeployEnvironmentTool(server, env0Service);
 
   return server;
 }

--- a/src/mcp/schemas/deploy-environment-schema.ts
+++ b/src/mcp/schemas/deploy-environment-schema.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+
+export const DeployEnvironmentSchema = z.object({
+  environmentId: z.string(),
+  revision: z.string().optional(),
+  comment: z.string().optional()
+});
+
+export type DeployEnvironmentParams = z.infer<typeof DeployEnvironmentSchema>;

--- a/src/mcp/tools/deploy-environment.ts
+++ b/src/mcp/tools/deploy-environment.ts
@@ -23,7 +23,7 @@ export function registerDeployEnvironmentTool(server: McpServer, env0Service: En
           content: [
             {
               type: 'text',
-              text: 'Environment deployed successfully. Result: ' + JSON.stringify(result)
+              text: `Environment deployed successfully. Result: ${JSON.stringify(result)}`
             }
           ]
         };

--- a/src/mcp/tools/deploy-environment.ts
+++ b/src/mcp/tools/deploy-environment.ts
@@ -11,8 +11,8 @@ export function registerDeployEnvironmentTool(server: McpServer, env0Service: En
     {
       title: 'Deploy Environment',
       description:
-        'This tool creates a new deployment for an existing env0 environment. ' +
-        'You can use the "get-environments" tool to find the environment ID of the environment you are looking for. ' +
+        'This tool creates a new deployment for an existing env0 environment.\n' +
+        'You can use the "get-environments" or "get-environment" tool to find the environment ID of the environment you are looking for.\n' +
         'This action **ALWAYS** requires approval from the user before execution.',
       inputSchema: DeployEnvironmentSchema.shape
     },

--- a/src/mcp/tools/deploy-environment.ts
+++ b/src/mcp/tools/deploy-environment.ts
@@ -11,7 +11,9 @@ export function registerDeployEnvironmentTool(server: McpServer, env0Service: En
     {
       title: 'Deploy Environment',
       description:
-        'Deploy an environment in env0. This tool creates a new deployment for an existing environment. You can use the "environments" resource to find the environment ID of the environment you are looking for. The deployment will be created and you can track its progress in the env0 dashboard. This action ALWAYS requires approval before execution.',
+        'This tool creates a new deployment for an existing env0 environment. ' +
+        'You can use the "environments" resource to find the environment ID of the environment you are looking for. ' +
+        'This action **ALWAYS** requires approval from the user before execution.',
       inputSchema: DeployEnvironmentSchema.shape
     },
     async (params: DeployEnvironmentParams) => {
@@ -21,7 +23,7 @@ export function registerDeployEnvironmentTool(server: McpServer, env0Service: En
           content: [
             {
               type: 'text',
-              text: JSON.stringify(result)
+              text: 'Environment deployed successfully. Result: ' + JSON.stringify(result)
             }
           ]
         };

--- a/src/mcp/tools/deploy-environment.ts
+++ b/src/mcp/tools/deploy-environment.ts
@@ -1,0 +1,41 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Env0Service } from '../../env0-service/env0-service';
+import {
+  type DeployEnvironmentParams,
+  DeployEnvironmentSchema
+} from '../schemas/deploy-environment-schema';
+
+export function registerDeployEnvironmentTool(server: McpServer, env0Service: Env0Service): void {
+  server.registerTool(
+    'deploy-environment',
+    {
+      title: 'Deploy Environment',
+      description:
+        'Deploy an environment in env0. This tool creates a new deployment for an existing environment. You can use the "environments" resource to find the environment ID of the environment you are looking for. The deployment will be created and you can track its progress in the env0 dashboard. This action ALWAYS requires approval before execution.',
+      inputSchema: DeployEnvironmentSchema.shape
+    },
+    async (params: DeployEnvironmentParams) => {
+      try {
+        const result = await env0Service.deployEnvironment(params);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result)
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error deploying environment: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/tools/deploy-environment.ts
+++ b/src/mcp/tools/deploy-environment.ts
@@ -12,7 +12,7 @@ export function registerDeployEnvironmentTool(server: McpServer, env0Service: En
       title: 'Deploy Environment',
       description:
         'This tool creates a new deployment for an existing env0 environment. ' +
-        'You can use the "environments" resource to find the environment ID of the environment you are looking for. ' +
+        'You can use the "get-environments" tool to find the environment ID of the environment you are looking for. ' +
         'This action **ALWAYS** requires approval from the user before execution.',
       inputSchema: DeployEnvironmentSchema.shape
     },

--- a/src/mcp/tools/get-environments.ts
+++ b/src/mcp/tools/get-environments.ts
@@ -6,7 +6,10 @@ import {
 } from '../schemas/get-environments-params-schema';
 import _ from 'lodash';
 
-const getEnvironments = async (env0Service: Env0Service, params: GetEnvironmentsParams) => {
+const getEnvironments = async (
+  env0Service: Env0Service,
+  params: GetEnvironmentsParams
+): Promise<object[]> => {
   if (!_.isNil(params.environmentId)) {
     const environment = await env0Service.getEnvironment(params.environmentId);
     return [environment];


### PR DESCRIPTION
- Add DeployEnvironmentSchema with environmentId, revision, and comment parameters
- Implement deployEnvironment method in Env0Service to call /mcp/environments/{id}/deployments endpoint
- Create deploy-environment MCP tool with proper error handling and approval requirement
- Register deploy-environment tool in MCP server
- Update schema to remove verbose descriptions for cleaner interface

This enables users to deploy env0 environments via MCP with optional revision and comment parameters.