### PR TITLE
Fix: Cloud Resources not filtering correcly

### DIFF
--- a/src/mcp/schemas/get-cloud-resources-params-schema.ts
+++ b/src/mcp/schemas/get-cloud-resources-params-schema.ts
@@ -8,11 +8,7 @@ const baseEQPattern = z.object({
 
 const optionalEQPattern = baseEQPattern.optional();
 
-const textPattern = baseEQPattern
-  .extend({
-    like: z.string().optional()
-  })
-  .optional();
+const textPattern = baseEQPattern.optional();
 
 export const GetCloudResourcesParamsSchema = z.object({
   orderBy: z
@@ -44,12 +40,21 @@ export const GetCloudResourcesParamsSchema = z.object({
       .describe(
         "The cloud provider ID. It's required that you provide either a configuration ID or a cloud provider"
       ),
-    managementType: optionalEQPattern,
+    managementType: optionalEQPattern.describe(
+      'An Optional filter for a specific IaC management type, ' +
+        "basically whether the resource is managed by IaC or not. Possible values for filtering are: 'IaC', 'ClickOps', 'API'"
+    ),
     region: optionalEQPattern,
-    type: textPattern,
+    type: textPattern.describe(
+      'An Optional filter for a specific cloud resource type. ' +
+        'For AWS it looks as follows: [ServiceName]:[ResourceType]. For example: "EC2:Instance", "S3:Bucket", "IAM:User", etc.'
+    ),
     name: textPattern,
     accountId: optionalEQPattern,
-    service: optionalEQPattern,
+    service: optionalEQPattern.describe(
+      'An Optional filter for a specific cloud service. ' +
+        'For AWS it looks as follows: "s3.amazonaws.com", "iam.amazonaws.com", etc.'
+    ),
     resourceId: textPattern,
     cloudId: textPattern,
     severity: z
@@ -58,7 +63,10 @@ export const GetCloudResourcesParamsSchema = z.object({
       })
       .optional(),
     searchBy: textPattern,
-    driftStatus: optionalEQPattern,
+    driftStatus: optionalEQPattern.describe(
+      'An Optional filter for a specific drift status. ' +
+        'Possible values are: "Drifted", "NotDrifted", "DriftRisk", "Unknown".'
+    ),
     environmentId: optionalEQPattern
   })
 });

--- a/src/mcp/tools/check-iac-job-status.ts
+++ b/src/mcp/tools/check-iac-job-status.ts
@@ -11,7 +11,7 @@ export function registerCheckIaCJobStatusTool(server: McpServer, env0Service: En
     {
       title: 'Check IaC Job Status',
       description:
-        'Check the status and retrieve results of an Infrastructure as Code generation job. Use this tool after calling generate-iac to monitor progress and get results.',
+        'Check the status and retrieve results of an Infrastructure as Code generation job. Use this tool after calling generate-iac to monitor progress and get results. Could take up to around 1 minute to get results.',
       inputSchema: CheckIaCJobStatusSchema.shape
     },
     async (params: CheckIaCJobStatusParams) => {


### PR DESCRIPTION
When using the GetCloudResources tool with filtering, it mostly fails to filter correctly. The filter's description is not accurate enough.
Updated the filters to make it easier to, for example, ask for resources that are not managed via IaC, or for specific types of resources

Also, adjust the description of the job status tool, to make the LLM more likely to wait longer