### PR TITLE
feat: add bearer token auth mode for hosted/enterprise deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,17 @@ ENV0_ORGANIZATION_ID=your-organization-id-here
 
 # Optional: Custom API URL (defaults to https://api.env0.com)
 ENV0_API_URL=https://api.env0.com
+
+# --- Bearer Token Authentication (for hosted/enterprise deployments) ---
+
+# Auth mode: "basic" (default) uses API key per-client, "bearer" validates JWTs server-side
+# AUTH_MODE=bearer
+
+# OIDC issuer URL — used to derive JWKS URI and validate the "iss" claim
+# OIDC_ISSUER=https://your-idp.example.com
+
+# Direct JWKS URI — alternative to OIDC_ISSUER if your provider doesn't use the standard path
+# JWKS_URI=https://your-idp.example.com/.well-known/jwks.json
+
+# Expected JWT audience claim (optional, adds an extra validation check)
+# AUTH_AUDIENCE=your-audience

--- a/README.md
+++ b/README.md
@@ -912,10 +912,13 @@ To set up the development environment and test the server:
 
 ## Authentication
 
-To allow the MCP server to connect to Env0's platform, you need to provide your API credentials.
-To create a new API key, please follow (this guide)[https://docs.env0.com/docs/api-keys]
+The server supports two authentication modes, controlled by the `AUTH_MODE` environment variable.
 
-Once you have your API credentials, you can configure them in the MCP server by setting the following environment variables:
+### Basic mode (default)
+
+Each MCP client provides env0 API credentials directly. This is the default behavior and requires no additional configuration.
+
+To create a new API key, please follow [this guide](https://docs.env0.com/docs/api-keys).
 
 ```bash
 export ENV0_API_KEY="your-api-key-id"
@@ -935,6 +938,30 @@ ENV0_API_SECRET=your-api-key-secret-here
 # Your env0 Organization ID (found in your env0 organization settings). This is required if you have multiple organizations
 ENV0_ORGANIZATION_ID=your-organization-id-here
 ```
+
+### Bearer mode (for hosted/enterprise deployments)
+
+In bearer mode, the server holds the env0 API credentials server-side. MCP clients authenticate to the server using JWT bearer tokens validated against your OIDC provider's JWKS endpoint. This is useful for hosted deployments where you don't want to distribute API keys to individual clients.
+
+```bash
+export AUTH_MODE=bearer
+
+# env0 API credentials (server-side only — not exposed to clients)
+export ENV0_API_KEY="your-api-key-id"
+export ENV0_API_SECRET="your-api-key-secret"
+
+# OIDC configuration (provide OIDC_ISSUER or JWKS_URI)
+export OIDC_ISSUER="https://your-idp.example.com"
+# Or set JWKS_URI directly if your provider doesn't use the standard /.well-known/jwks.json path
+# export JWKS_URI="https://your-idp.example.com/.well-known/jwks.json"
+
+# Optional: expected JWT audience claim
+# export AUTH_AUDIENCE="your-audience"
+```
+
+Clients must include an `Authorization: Bearer <token>` header on all HTTP requests. Requests without a valid token receive a `401 Unauthorized` response.
+
+> **Note:** Bearer mode only applies to HTTP transport. In stdio mode, the `AUTH_MODE` setting is ignored since there is no HTTP layer to authenticate.
 
 ## Docker Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "axios": "^1.11.0",
         "dotenv": "17.2.1",
         "express": "5.1.0",
+        "jose": "^6.2.3",
         "lodash": "4.17.21",
         "morgan": "1.10.1",
+        "tsx": "4.20.4",
         "zod": "3.25.76"
       },
       "devDependencies": {
@@ -31,7 +33,6 @@
         "nodemon": "3.1.10",
         "prettier": "3.6.2",
         "ts-node": "10.9.2",
-        "tsx": "4.20.4",
         "typescript": "5.9.2"
       }
     },
@@ -55,7 +56,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -72,7 +72,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -89,7 +88,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -106,7 +104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -123,7 +120,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -140,7 +136,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -157,7 +152,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -174,7 +168,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -191,7 +184,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -208,7 +200,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -225,7 +216,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -242,7 +232,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -259,7 +248,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -276,7 +264,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -293,7 +280,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -310,7 +296,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -327,7 +312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -344,7 +328,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -361,7 +344,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -378,7 +360,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -395,7 +376,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -412,7 +392,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -429,7 +408,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -446,7 +424,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -463,7 +440,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -480,7 +456,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1808,7 +1783,6 @@
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
       "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2432,7 +2406,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2493,7 +2466,6 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -2749,6 +2721,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3369,7 +3350,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -3758,7 +3738,6 @@
       "version": "4.20.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
       "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/axios": "^0.14.4",
     "@types/express": "5.0.3",
+    "@types/lodash": "4.17.20",
     "@types/node": "24.2.1",
     "@typescript-eslint/eslint-plugin": "8.39.1",
     "@typescript-eslint/parser": "8.39.1",
@@ -34,17 +35,17 @@
     "nodemon": "3.1.10",
     "prettier": "3.6.2",
     "ts-node": "10.9.2",
-    "typescript": "5.9.2",
-    "@types/lodash": "4.17.20"
+    "typescript": "5.9.2"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.2",
     "axios": "^1.11.0",
     "dotenv": "17.2.1",
     "express": "5.1.0",
-    "morgan": "1.10.1",
-    "zod": "3.25.76",
+    "jose": "^6.2.3",
     "lodash": "4.17.21",
-    "tsx": "4.20.4"
+    "morgan": "1.10.1",
+    "tsx": "4.20.4",
+    "zod": "3.25.76"
   }
 }

--- a/src/auth/bearer-auth.ts
+++ b/src/auth/bearer-auth.ts
@@ -1,0 +1,45 @@
+import { type JWTPayload, createRemoteJWKSet, jwtVerify } from 'jose';
+import type { NextFunction, Request, Response } from 'express';
+
+export interface BearerAuthConfig {
+  jwksUri: string;
+  issuer?: string | undefined;
+  audience?: string | undefined;
+}
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJWKS(jwksUri: string): ReturnType<typeof createRemoteJWKSet> {
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(jwksUri));
+  }
+  return jwks;
+}
+
+export function bearerAuth(config: BearerAuthConfig) {
+  const verifyOptions: { issuer?: string; audience?: string } = {};
+  if (config.issuer) verifyOptions.issuer = config.issuer;
+  if (config.audience) verifyOptions.audience = config.audience;
+
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      res.status(401).json({ error: 'Missing or invalid Authorization header' });
+      return;
+    }
+
+    const token = authHeader.slice(7);
+
+    try {
+      const { payload } = await jwtVerify(token, getJWKS(config.jwksUri), verifyOptions);
+
+      (req as Request & { auth?: JWTPayload }).auth = payload;
+      next();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Token verification failed';
+      console.error('Bearer auth failed:', message);
+      res.status(401).json({ error: 'Invalid or expired token' });
+    }
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,16 +14,27 @@ const port = process.env.PORT || 3000;
 export async function startServer(): Promise<void> {
   const isHttpMode = process.argv.includes('--http') || process.env.MCP_TRANSPORT === 'http';
 
-  const config = getAndValidateConfig();
-  const env0Client = new Env0Client(config);
-  const env0Service = new Env0Service(config, env0Client);
+  const serverConfig = getAndValidateConfig();
+  const env0Client = new Env0Client(serverConfig.env0);
+  const env0Service = new Env0Service(serverConfig.env0, env0Client);
 
   const server = createMcpServer(env0Service);
 
   if (isHttpMode) {
     console.log(`Initializing Env0 MCP Server in HTTP mode on port ${port}...`);
-    await startHttpServer(+port, server);
+    console.log(`Auth mode: ${serverConfig.authMode}`);
+    await startHttpServer({
+      port: +port,
+      mcpServer: server,
+      bearerAuthConfig: serverConfig.bearerAuth
+    });
   } else {
+    if (serverConfig.authMode === 'bearer') {
+      console.warn(
+        'Warning: AUTH_MODE=bearer has no effect in stdio mode. ' +
+          'Bearer auth is only applied to HTTP transport.'
+      );
+    }
     const transport = new StdioServerTransport();
     await server.connect(transport);
   }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,18 +1,43 @@
 import type { Env0Config } from '../env0-service/env0-client';
+import type { BearerAuthConfig } from '../auth/bearer-auth';
 
-export function getAndValidateConfig(overrides?: Partial<Env0Config>): Env0Config {
-  const config: Env0Config = {
+export type AuthMode = 'basic' | 'bearer';
+
+export interface ServerConfig {
+  env0: Env0Config;
+  authMode: AuthMode;
+  bearerAuth?: BearerAuthConfig | undefined;
+}
+
+export function getAndValidateConfig(overrides?: Partial<Env0Config>): ServerConfig {
+  const authMode = (process.env.AUTH_MODE || 'basic') as AuthMode;
+
+  if (authMode !== 'basic' && authMode !== 'bearer') {
+    throw new Error(`Invalid AUTH_MODE: ${authMode}. Must be "basic" or "bearer".`);
+  }
+
+  const env0Config: Env0Config = {
     apiUrl: overrides?.apiUrl || process.env.ENV0_API_URL || 'https://api.env0.com',
     organizationId: overrides?.organizationId || process.env.ENV0_ORGANIZATION_ID || '',
     apiKeyId: overrides?.apiKeyId || process.env.ENV0_API_KEY || '',
     apiKeySecret: overrides?.apiKeySecret || process.env.ENV0_API_SECRET || ''
   };
 
-  validateConfig(config);
-  return config;
+  validateEnv0Config(env0Config);
+
+  const serverConfig: ServerConfig = {
+    env0: env0Config,
+    authMode
+  };
+
+  if (authMode === 'bearer') {
+    serverConfig.bearerAuth = getBearerAuthConfig();
+  }
+
+  return serverConfig;
 }
 
-function validateConfig(config: Env0Config): void {
+function validateEnv0Config(config: Env0Config): void {
   if (!config.apiKeyId || !config.apiKeySecret) {
     throw new Error('Missing required env0 API credentials (ENV0_API_KEY and ENV0_API_SECRET)');
   }
@@ -22,4 +47,32 @@ function validateConfig(config: Env0Config): void {
   } catch {
     throw new Error(`Invalid API URL: ${config.apiUrl}`);
   }
+}
+
+function getBearerAuthConfig(): BearerAuthConfig {
+  const issuer = process.env.OIDC_ISSUER;
+  const jwksUri = process.env.JWKS_URI;
+  const audience = process.env.AUTH_AUDIENCE;
+
+  const resolvedJwksUri =
+    jwksUri || (issuer ? `${issuer.replace(/\/$/, '')}/.well-known/jwks.json` : '');
+
+  if (!resolvedJwksUri) {
+    throw new Error(
+      'Bearer auth requires JWKS_URI or OIDC_ISSUER to be set. ' +
+        'Set JWKS_URI for a direct JWKS endpoint, or OIDC_ISSUER to derive it from the issuer URL.'
+    );
+  }
+
+  try {
+    new URL(resolvedJwksUri);
+  } catch {
+    throw new Error(`Invalid JWKS URI: ${resolvedJwksUri}`);
+  }
+
+  return {
+    jwksUri: resolvedJwksUri,
+    issuer,
+    audience
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,17 @@
 import { randomUUID } from 'node:crypto';
-import express, { type Request, type Response } from 'express';
+import express, { type Request, type RequestHandler, type Response } from 'express';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { Server } from 'http';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { type BearerAuthConfig, bearerAuth } from './auth/bearer-auth';
+
+export interface HttpServerOptions {
+  port: number;
+  mcpServer: McpServer;
+  bearerAuthConfig?: BearerAuthConfig | undefined;
+}
 
 let httpServer: Server | null = null;
 const transports = {
@@ -12,8 +19,15 @@ const transports = {
   sse: {} as Record<string, SSEServerTransport>
 };
 
-export async function startHttpServer(port: number, mcpServer: McpServer): Promise<void> {
+export async function startHttpServer(options: HttpServerOptions): Promise<void> {
+  const { port, mcpServer, bearerAuthConfig } = options;
   const app = express();
+
+  if (bearerAuthConfig) {
+    const authMiddleware = bearerAuth(bearerAuthConfig);
+    app.use(authMiddleware as RequestHandler);
+    console.log('Bearer token authentication enabled');
+  }
 
   // Parse JSON requests for the Streamable HTTP endpoint only, will break SSE endpoint
   app.use('/mcp', express.json());


### PR DESCRIPTION
Adds an optional AUTH_MODE=bearer that validates incoming JWTs against a configurable JWKS/OIDC endpoint, keeping env0 API credentials server-side. Backward compatible — basic mode (default) is unchanged.