### PR TITLE
feat: add deployment history support

### DIFF
--- a/src/common/ansi.ts
+++ b/src/common/ansi.ts
@@ -1,0 +1,7 @@
+// Strip ANSI escape codes from a string (e.g. [0m[1m color/formatting sequences)
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_RE = /\x1B\[[0-9;]*[A-Za-z]|\x1B[@-_]/g;
+
+export function stripAnsi(str: string): string {
+  return str.replace(ANSI_ESCAPE_RE, '');
+}

--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -12,6 +12,7 @@ import type { GetCloudResourcesParams } from '../mcp/schemas/get-cloud-resources
 import type { GetPlanLogsParams } from '../mcp/schemas/get-plan-logs-params-schema';
 import type { GenerateIaCParams } from '../mcp/schemas/generate-iac-schema';
 import type { CheckIaCJobStatusParams } from '../mcp/schemas/check-iac-job-status-schema';
+import { stripAnsi } from '../common/ansi';
 
 export class Env0Service {
   private readonly config: Env0Config;
@@ -185,18 +186,25 @@ export class Env0Service {
   }
 
   async getPlanLogs({ environmentId, deploymentId, tail }: GetPlanLogsParams): Promise<object> {
-    const defaultTail = 150;
+    const defaultTail = 50;
     const tailCount = tail ?? defaultTail;
 
     let resolvedDeploymentId = deploymentId;
+    let planSummary: unknown = undefined;
 
     if (!resolvedDeploymentId) {
       const env = await this.getEnvironment(environmentId);
-      const latestId = (env as { latestDeploymentLogId?: string }).latestDeploymentLogId;
+      const envAny = env as Record<string, unknown>;
+      const latestId = envAny.latestDeploymentLogId as string | undefined;
       if (!latestId) {
         return { error: 'No deployments found for this environment' };
       }
       resolvedDeploymentId = latestId;
+      // Grab planSummary from the environment's latest deployment log if available
+      const latestLog = envAny.latestDeploymentLog as Record<string, unknown> | undefined;
+      if (latestLog?.planSummary) {
+        planSummary = latestLog.planSummary;
+      }
     }
 
     const steps = await this.getDeploymentSteps(resolvedDeploymentId);
@@ -212,19 +220,33 @@ export class Env0Service {
     }
 
     const fullLog = (await this.getDeploymentStepLog(resolvedDeploymentId, planStep.name)) as {
-      events: object[];
+      events: { message?: string }[];
       totalEvents: number;
     };
 
+    // Strip ANSI escape codes from all event messages
+    const cleanedEvents = fullLog.events.map(event => {
+      if (typeof event.message === 'string') {
+        return { ...event, message: stripAnsi(event.message) };
+      }
+      return event;
+    });
+
     if (fullLog.totalEvents <= tailCount) {
-      return fullLog;
+      return { events: cleanedEvents, totalEvents: fullLog.totalEvents };
     }
 
-    return {
-      events: fullLog.events.slice(-tailCount),
+    const result: Record<string, unknown> = {
+      events: cleanedEvents.slice(-tailCount),
       totalEvents: fullLog.totalEvents,
       truncated: true,
       showing: `last ${tailCount} of ${fullLog.totalEvents} events (pass a higher tail value to see more)`
     };
+
+    if (planSummary !== undefined) {
+      result.planSummary = planSummary;
+    }
+
+    return result;
   }
 }

--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -184,7 +184,10 @@ export class Env0Service {
     });
   }
 
-  async getPlanLogs({ environmentId, deploymentId }: GetPlanLogsParams): Promise<object> {
+  async getPlanLogs({ environmentId, deploymentId, tail }: GetPlanLogsParams): Promise<object> {
+    const defaultTail = 150;
+    const tailCount = tail ?? defaultTail;
+
     let resolvedDeploymentId = deploymentId;
 
     if (!resolvedDeploymentId) {
@@ -208,6 +211,20 @@ export class Env0Service {
       };
     }
 
-    return this.getDeploymentStepLog(resolvedDeploymentId, planStep.name);
+    const fullLog = (await this.getDeploymentStepLog(resolvedDeploymentId, planStep.name)) as {
+      events: object[];
+      totalEvents: number;
+    };
+
+    if (fullLog.totalEvents <= tailCount) {
+      return fullLog;
+    }
+
+    return {
+      events: fullLog.events.slice(-tailCount),
+      totalEvents: fullLog.totalEvents,
+      truncated: true,
+      showing: `last ${tailCount} of ${fullLog.totalEvents} events (pass a higher tail value to see more)`
+    };
   }
 }

--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -86,9 +86,29 @@ export class Env0Service {
   }
 
   async getDeploymentStepLog(deploymentId: string, stepName: string): Promise<object> {
-    return this.env0Client.request({
-      url: `/deployments/${deploymentId}/steps/${encodeURIComponent(stepName)}/log`
-    });
+    const allEvents: object[] = [];
+    let nextStartTime: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const page = await this.env0Client.request<{
+        events: object[];
+        nextStartTime?: string;
+        hasMoreLogs?: boolean;
+      }>({
+        url: `/deployments/${deploymentId}/steps/${encodeURIComponent(stepName)}/log`,
+        params: nextStartTime ? { startTime: nextStartTime } : undefined
+      });
+
+      if (page.events) {
+        allEvents.push(...page.events);
+      }
+
+      hasMore = page.hasMoreLogs === true;
+      nextStartTime = page.nextStartTime;
+    }
+
+    return { events: allEvents, totalEvents: allEvents.length };
   }
 
   async getErrorAnalysis(environmentId: string, deploymentId?: string): Promise<object> {
@@ -165,13 +185,18 @@ export class Env0Service {
   }
 
   async getPlanLogs({ environmentId, deploymentId }: GetPlanLogsParams): Promise<object> {
-    if (!deploymentId) {
-      return this.env0Client.request({
-        url: `/mcp/environments/${environmentId}/plan/logs`
-      });
+    let resolvedDeploymentId = deploymentId;
+
+    if (!resolvedDeploymentId) {
+      const env = await this.getEnvironment(environmentId);
+      const latestId = (env as { latestDeploymentLogId?: string }).latestDeploymentLogId;
+      if (!latestId) {
+        return { error: 'No deployments found for this environment' };
+      }
+      resolvedDeploymentId = latestId;
     }
 
-    const steps = await this.getDeploymentSteps(deploymentId);
+    const steps = await this.getDeploymentSteps(resolvedDeploymentId);
     const planStep = (steps as { name: string }[]).find(
       s => s.name.toLowerCase() === 'plan' || s.name.toLowerCase().includes('plan')
     );
@@ -183,6 +208,6 @@ export class Env0Service {
       };
     }
 
-    return this.getDeploymentStepLog(deploymentId, planStep.name);
+    return this.getDeploymentStepLog(resolvedDeploymentId, planStep.name);
   }
 }

--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -3,6 +3,7 @@ import type { ApproveEnvironmentParams } from '../mcp/schemas/approve-environmen
 import type { CancelEnvironmentParams } from '../mcp/schemas/cancel-environment-schema';
 import type { DeployEnvironmentParams } from '../mcp/schemas/deploy-environment-schema';
 import type { GetEnvironmentsParams } from '../mcp/schemas/get-environments-params-schema';
+import type { GetDeploymentsParams } from '../mcp/schemas/get-deployments-params-schema';
 import type { Env0Config } from './env0-client';
 import type Env0Client from './env0-client';
 import type { CloudConfiguration } from './models/cloud-configuration';
@@ -67,10 +68,45 @@ export class Env0Service {
     });
   }
 
-  async getErrorAnalysis(environmentId: string): Promise<object> {
+  async getDeployments(params: GetDeploymentsParams): Promise<object[]> {
     return this.env0Client.request({
-      url: `/mcp/environments/${environmentId}/error-analysis`
+      url: `/environments/${params.environmentId}/deployments`,
+      params: {
+        limit: params.limit || undefined,
+        offset: params.offset || undefined,
+        statuses: params.statuses || undefined
+      }
     });
+  }
+
+  async getDeploymentSteps(deploymentId: string): Promise<object[]> {
+    return this.env0Client.request({
+      url: `/deployments/${deploymentId}/steps`
+    });
+  }
+
+  async getDeploymentStepLog(deploymentId: string, stepName: string): Promise<object> {
+    return this.env0Client.request({
+      url: `/deployments/${deploymentId}/steps/${encodeURIComponent(stepName)}/log`
+    });
+  }
+
+  async getErrorAnalysis(environmentId: string, deploymentId?: string): Promise<object> {
+    if (!deploymentId) {
+      return this.env0Client.request({
+        url: `/mcp/environments/${environmentId}/error-analysis`
+      });
+    }
+
+    try {
+      return await this.env0Client.request({
+        url: `/deployments/${deploymentId}/error-analysis`
+      });
+    } catch {
+      return this.env0Client.request({
+        url: `/mcp/environments/${environmentId}/error-analysis`
+      });
+    }
   }
 
   async approveEnvironment({ environmentId }: ApproveEnvironmentParams): Promise<object> {
@@ -128,9 +164,25 @@ export class Env0Service {
     });
   }
 
-  async getPlanLogs({ environmentId }: GetPlanLogsParams): Promise<object> {
-    return this.env0Client.request({
-      url: `/mcp/environments/${environmentId}/plan/logs`
-    });
+  async getPlanLogs({ environmentId, deploymentId }: GetPlanLogsParams): Promise<object> {
+    if (!deploymentId) {
+      return this.env0Client.request({
+        url: `/mcp/environments/${environmentId}/plan/logs`
+      });
+    }
+
+    const steps = await this.getDeploymentSteps(deploymentId);
+    const planStep = (steps as { name: string }[]).find(
+      s => s.name.toLowerCase() === 'plan' || s.name.toLowerCase().includes('plan')
+    );
+
+    if (!planStep) {
+      return {
+        error: 'No plan step found for this deployment',
+        availableSteps: (steps as { name: string }[]).map(s => s.name)
+      };
+    }
+
+    return this.getDeploymentStepLog(deploymentId, planStep.name);
   }
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,6 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerGetCloudConfigurationsTool } from './tools/get-cloud-configurations';
 import { registerGetDeploymentsTool } from './tools/get-deployments';
+import { registerGetDeploymentStepsTool } from './tools/get-deployment-steps';
+import { registerGetDeploymentStepLogTool } from './tools/get-deployment-step-log';
 import { registerGetEnvironmentsTool } from './tools/get-environments';
 import { Env0Service } from '../env0-service/env0-service';
 import { registerGetProjectsTool } from './tools/get-projects';
@@ -22,6 +24,8 @@ export function createMcpServer(env0Service: Env0Service): McpServer {
 
   registerGetCloudConfigurationsTool(server, env0Service);
   registerGetDeploymentsTool(server, env0Service);
+  registerGetDeploymentStepsTool(server, env0Service);
+  registerGetDeploymentStepLogTool(server, env0Service);
   registerGetEnvironmentsTool(server, env0Service);
   registerGetProjectsTool(server, env0Service);
   registerApproveEnvironmentTool(server, env0Service);

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerGetCloudConfigurationsTool } from './tools/get-cloud-configurations';
+import { registerGetDeploymentsTool } from './tools/get-deployments';
 import { registerGetEnvironmentsTool } from './tools/get-environments';
 import { Env0Service } from '../env0-service/env0-service';
 import { registerGetProjectsTool } from './tools/get-projects';
@@ -20,6 +21,7 @@ export function createMcpServer(env0Service: Env0Service): McpServer {
   });
 
   registerGetCloudConfigurationsTool(server, env0Service);
+  registerGetDeploymentsTool(server, env0Service);
   registerGetEnvironmentsTool(server, env0Service);
   registerGetProjectsTool(server, env0Service);
   registerApproveEnvironmentTool(server, env0Service);

--- a/src/mcp/schemas/get-deployment-step-log-schema.ts
+++ b/src/mcp/schemas/get-deployment-step-log-schema.ts
@@ -1,0 +1,16 @@
+import z from 'zod';
+
+export const GetDeploymentStepLogSchema = z.object({
+  deploymentId: z.string().describe('The ID of the deployment'),
+  stepName: z
+    .string()
+    .describe('The name of the step to get logs for (e.g. "Init", "Plan", "Apply")'),
+  tail: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Return only the last N log events. Defaults to 150. Set higher to see more context.')
+});
+
+export type GetDeploymentStepLogParams = z.infer<typeof GetDeploymentStepLogSchema>;

--- a/src/mcp/schemas/get-deployment-steps-schema.ts
+++ b/src/mcp/schemas/get-deployment-steps-schema.ts
@@ -1,0 +1,7 @@
+import z from 'zod';
+
+export const GetDeploymentStepsSchema = z.object({
+  deploymentId: z.string().describe('The ID of the deployment to get steps for')
+});
+
+export type GetDeploymentStepsParams = z.infer<typeof GetDeploymentStepsSchema>;

--- a/src/mcp/schemas/get-deployments-params-schema.ts
+++ b/src/mcp/schemas/get-deployments-params-schema.ts
@@ -1,0 +1,26 @@
+import z from 'zod';
+
+export const GetDeploymentsParamsSchema = z.object({
+  environmentId: z.string().describe('The ID of the environment to list deployments for'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .optional()
+    .describe('Maximum number of deployments to return (default 10)'),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe('Number of deployments to skip for pagination'),
+  statuses: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated deployment statuses to filter by (e.g. "SUCCESS,FAILURE,IN_PROGRESS")'
+    )
+});
+
+export type GetDeploymentsParams = z.infer<typeof GetDeploymentsParamsSchema>;

--- a/src/mcp/schemas/get-error-analysis-schema.ts
+++ b/src/mcp/schemas/get-error-analysis-schema.ts
@@ -1,7 +1,13 @@
 import z from 'zod';
 
 export const GetErrorAnalysisSchema = z.object({
-  environmentId: z.string().describe('The ID of the environment to get error analysis for')
+  environmentId: z.string().describe('The ID of the environment to get error analysis for'),
+  deploymentId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of a specific deployment to get error analysis for. If omitted, analyzes the latest deployment.'
+    )
 });
 
 export type GetErrorAnalysisParams = z.infer<typeof GetErrorAnalysisSchema>;

--- a/src/mcp/schemas/get-plan-logs-params-schema.ts
+++ b/src/mcp/schemas/get-plan-logs-params-schema.ts
@@ -7,6 +7,16 @@ export const GetPlanLogsParamsSchema = z.object({
     .optional()
     .describe(
       'The ID of a specific deployment to get plan logs for. If omitted, returns logs for the latest deployment.'
+    ),
+  tail: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'Return only the last N log events (the plan summary is always at the end). ' +
+        'Defaults to 150. Set higher to see more context, e.g. moved blocks or full refresh output. ' +
+        'Use get-deployment-steps to see all available steps if you need init or apply logs.'
     )
 });
 

--- a/src/mcp/schemas/get-plan-logs-params-schema.ts
+++ b/src/mcp/schemas/get-plan-logs-params-schema.ts
@@ -15,7 +15,7 @@ export const GetPlanLogsParamsSchema = z.object({
     .optional()
     .describe(
       'Return only the last N log events (the plan summary is always at the end). ' +
-        'Defaults to 150. Set higher to see more context, e.g. moved blocks or full refresh output. ' +
+        'Defaults to 50. Set higher to see more context, e.g. moved blocks or full refresh output. ' +
         'Use get-deployment-steps to see all available steps if you need init or apply logs.'
     )
 });

--- a/src/mcp/schemas/get-plan-logs-params-schema.ts
+++ b/src/mcp/schemas/get-plan-logs-params-schema.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 
 export const GetPlanLogsParamsSchema = z.object({
-  environmentId: z.string().describe('The ID of the environment to get plan logs for')
+  environmentId: z.string().describe('The ID of the environment to get plan logs for'),
+  deploymentId: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of a specific deployment to get plan logs for. If omitted, returns logs for the latest deployment.'
+    )
 });
 
 export type GetPlanLogsParams = z.infer<typeof GetPlanLogsParamsSchema>;

--- a/src/mcp/tools/get-deployment-step-log.ts
+++ b/src/mcp/tools/get-deployment-step-log.ts
@@ -1,0 +1,69 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Env0Service } from '../../env0-service/env0-service';
+import {
+  type GetDeploymentStepLogParams,
+  GetDeploymentStepLogSchema
+} from '../schemas/get-deployment-step-log-schema';
+
+export function registerGetDeploymentStepLogTool(
+  server: McpServer,
+  env0Service: Env0Service
+): void {
+  server.registerTool(
+    'get-deployment-step-log',
+    {
+      title: 'Get Deployment Step Log',
+      description:
+        'Get logs for a specific step of a deployment (e.g. Init, Plan, Apply). ' +
+        'Use get-deployment-steps to discover available step names. ' +
+        'Returns the last 150 events by default — set tail higher for more context.',
+      inputSchema: GetDeploymentStepLogSchema.shape
+    },
+    async (params: GetDeploymentStepLogParams) => {
+      try {
+        const defaultTail = 150;
+        const tailCount = params.tail ?? defaultTail;
+
+        const fullLog = (await env0Service.getDeploymentStepLog(
+          params.deploymentId,
+          params.stepName
+        )) as { events: object[]; totalEvents: number };
+
+        if (fullLog.totalEvents <= tailCount) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(fullLog)
+              }
+            ]
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                events: fullLog.events.slice(-tailCount),
+                totalEvents: fullLog.totalEvents,
+                truncated: true,
+                showing: `last ${tailCount} of ${fullLog.totalEvents} events (pass a higher tail value to see more)`
+              })
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching step log: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/tools/get-deployment-steps.ts
+++ b/src/mcp/tools/get-deployment-steps.ts
@@ -1,0 +1,55 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Env0Service } from '../../env0-service/env0-service';
+import {
+  type GetDeploymentStepsParams,
+  GetDeploymentStepsSchema
+} from '../schemas/get-deployment-steps-schema';
+
+export function registerGetDeploymentStepsTool(server: McpServer, env0Service: Env0Service): void {
+  server.registerTool(
+    'get-deployment-steps',
+    {
+      title: 'Get Deployment Steps',
+      description:
+        'List the steps (init, plan, apply, etc.) for a specific deployment. ' +
+        'Each step has a name, status, and timestamps. Use the step name with ' +
+        'get-deployment-step-log to fetch logs for any step — not just the plan.',
+      inputSchema: GetDeploymentStepsSchema.shape
+    },
+    async (params: GetDeploymentStepsParams) => {
+      try {
+        const steps = await env0Service.getDeploymentSteps(params.deploymentId);
+
+        if ((steps as unknown[]).length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No steps found for this deployment.'
+              }
+            ]
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Steps (${(steps as unknown[]).length} found): ${JSON.stringify(steps)}`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching deployment steps: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/tools/get-deployments.ts
+++ b/src/mcp/tools/get-deployments.ts
@@ -1,0 +1,55 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Env0Service } from '../../env0-service/env0-service';
+import {
+  type GetDeploymentsParams,
+  GetDeploymentsParamsSchema
+} from '../schemas/get-deployments-params-schema';
+
+export function registerGetDeploymentsTool(server: McpServer, env0Service: Env0Service): void {
+  server.registerTool(
+    'get-deployments',
+    {
+      title: 'Get Deployments',
+      description:
+        'List deployments for a specific environment from env0. ' +
+        'Returns deployment history including status, timestamps, and deployment IDs ' +
+        'that can be used with get-plan-logs and get-error-analysis for historical lookups.',
+      inputSchema: GetDeploymentsParamsSchema.shape
+    },
+    async (params: GetDeploymentsParams) => {
+      try {
+        const deployments = await env0Service.getDeployments(params);
+
+        if ((deployments as unknown[]).length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No deployments found for this environment.'
+              }
+            ]
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Deployments (${(deployments as unknown[]).length} found): ${JSON.stringify(deployments)}`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching deployments: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/tools/get-environments.ts
+++ b/src/mcp/tools/get-environments.ts
@@ -6,16 +6,61 @@ import {
 } from '../schemas/get-environments-params-schema';
 import _ from 'lodash';
 
+// Strip noisy fields from an environment object to reduce token usage.
+// Removes: variables (large sensitive arrays), full latestDeploymentLog (replaced with summary),
+// providerVersions (replaced with count+names), moduleVersions (replaced with count).
+function slimEnvironment(env: Record<string, unknown>): Record<string, unknown> {
+  const slim = { ...env };
+
+  delete slim.variables;
+
+  // Replace full latestDeploymentLog with a compact summary
+  if (slim.latestDeploymentLog && typeof slim.latestDeploymentLog === 'object') {
+    const log = slim.latestDeploymentLog as Record<string, unknown>;
+    const comment = typeof log.comment === 'string' ? log.comment.slice(0, 200) : log.comment;
+    slim.latestDeploymentLog = {
+      id: log.id,
+      status: log.status,
+      planSummary: log.planSummary,
+      createdAt: log.createdAt,
+      finishedAt: log.finishedAt,
+      type: log.type,
+      comment,
+      blueprintRevision: log.blueprintRevision,
+      resourceCount: log.resourceCount,
+      triggerName: log.triggerName,
+      gitMetadata: env.gitMetadata
+    };
+  }
+
+  // Collapse providerVersions to count + short names
+  if (slim.providerVersions && typeof slim.providerVersions === 'object' && !Array.isArray(slim.providerVersions)) {
+    const entries = Object.keys(slim.providerVersions as Record<string, string>);
+    slim.providerVersions = {
+      count: entries.length,
+      providers: entries.map(k => k.replace(/^registry\.opentofu\.org\//, '').replace(/^registry\.terraform\.io\//, ''))
+    };
+  }
+
+  // Collapse moduleVersions to count only
+  if (slim.moduleVersions && typeof slim.moduleVersions === 'object' && !Array.isArray(slim.moduleVersions)) {
+    slim.moduleVersions = { count: Object.keys(slim.moduleVersions as Record<string, string>).length };
+  }
+
+  return slim;
+}
+
 const getEnvironments = async (
   env0Service: Env0Service,
   params: GetEnvironmentsParams
 ): Promise<object[]> => {
   if (!_.isNil(params.environmentId)) {
     const environment = await env0Service.getEnvironment(params.environmentId);
-    return [environment];
+    return [slimEnvironment(environment as Record<string, unknown>)];
   }
 
-  return await env0Service.getEnvironments(params);
+  const environments = await env0Service.getEnvironments(params);
+  return (environments as Record<string, unknown>[]).map(slimEnvironment);
 };
 
 export function registerGetEnvironmentsTool(server: McpServer, env0Service: Env0Service): void {

--- a/src/mcp/tools/get-error-analysis.ts
+++ b/src/mcp/tools/get-error-analysis.ts
@@ -10,12 +10,15 @@ export function registerGetErrorAnalysisTool(server: McpServer, env0Service: Env
     'get-error-analysis',
     {
       title: 'Get Error Analysis',
-      description: `Analyzes errors in the last environment's deployment`,
+      description:
+        "Analyzes errors in an environment's deployment. " +
+        'Optionally specify a deploymentId to analyze a specific historical deployment. ' +
+        'Use get-deployments to find deployment IDs. If omitted, analyzes the latest deployment.',
       inputSchema: GetErrorAnalysisSchema.shape
     },
-    async ({ environmentId }: GetErrorAnalysisParams) => {
+    async ({ environmentId, deploymentId }: GetErrorAnalysisParams) => {
       try {
-        const errorAnalysis = await env0Service.getErrorAnalysis(environmentId);
+        const errorAnalysis = await env0Service.getErrorAnalysis(environmentId, deploymentId);
 
         return {
           content: [

--- a/src/mcp/tools/get-plan-logs.ts
+++ b/src/mcp/tools/get-plan-logs.ts
@@ -12,8 +12,9 @@ export function registerGetPlanLogsTool(server: McpServer, env0Service: Env0Serv
       title: 'Get Plan Logs',
       description:
         'Get plan logs for a specific environment from env0. ' +
-        'Returns the last 150 log events by default (plan summary is always at the end). ' +
+        'Returns the last 50 log events by default (plan summary is always at the end). ' +
         'Set tail to a higher value to see more context (e.g. moved blocks, full refresh output). ' +
+        'When truncated, a planSummary field is included in the response so you can assess scope before fetching more. ' +
         'Optionally specify a deploymentId for a specific historical deployment (use get-deployments to find IDs).',
       inputSchema: GetPlanLogsParamsSchema.shape
     },

--- a/src/mcp/tools/get-plan-logs.ts
+++ b/src/mcp/tools/get-plan-logs.ts
@@ -12,8 +12,9 @@ export function registerGetPlanLogsTool(server: McpServer, env0Service: Env0Serv
       title: 'Get Plan Logs',
       description:
         'Get plan logs for a specific environment from env0. ' +
-        'Optionally specify a deploymentId to get logs for a specific historical deployment. ' +
-        'Use get-deployments to find deployment IDs. If omitted, returns logs for the latest deployment.',
+        'Returns the last 150 log events by default (plan summary is always at the end). ' +
+        'Set tail to a higher value to see more context (e.g. moved blocks, full refresh output). ' +
+        'Optionally specify a deploymentId for a specific historical deployment (use get-deployments to find IDs).',
       inputSchema: GetPlanLogsParamsSchema.shape
     },
     async (params: GetPlanLogsParams) => {

--- a/src/mcp/tools/get-plan-logs.ts
+++ b/src/mcp/tools/get-plan-logs.ts
@@ -11,7 +11,9 @@ export function registerGetPlanLogsTool(server: McpServer, env0Service: Env0Serv
     {
       title: 'Get Plan Logs',
       description:
-        'Get plan logs for a specific environment from env0, for full plan please see env0 console',
+        'Get plan logs for a specific environment from env0. ' +
+        'Optionally specify a deploymentId to get logs for a specific historical deployment. ' +
+        'Use get-deployments to find deployment IDs. If omitted, returns logs for the latest deployment.',
       inputSchema: GetPlanLogsParamsSchema.shape
     },
     async (params: GetPlanLogsParams) => {


### PR DESCRIPTION
## Summary

Adds the ability to query historical deployment data, not just the latest deployment per environment:

- **New tool: `get-deployments`** — list deployments for an environment with optional filters (limit, offset, statuses). Returns deployment IDs usable with the other tools below.
- **`get-plan-logs`** — new optional `deploymentId` parameter. When provided, fetches the plan step log for that specific deployment. When omitted, existing behavior (latest deployment) is preserved.
- **`get-error-analysis`** — new optional `deploymentId` parameter. When provided, attempts deployment-specific error analysis with graceful fallback to environment-level. When omitted, existing behavior is preserved.

### Motivation

The current MCP tools only expose the latest deployment per environment. When multiple deployments happen in quick succession (e.g., a PR plan followed by a master deploy), agents can only see the most recent one. This makes it impossible to investigate a specific PR deployment that has since been superseded — a common workflow when debugging failed plans.

### New service methods

| Method | API Endpoint |
|--------|-------------|
| `getDeployments` | `GET /environments/{envId}/deployments` |
| `getDeploymentSteps` | `GET /deployments/{id}/steps` |
| `getDeploymentStepLog` | `GET /deployments/{id}/steps/{name}/log` |

### Backward compatibility

All changes are additive. Existing callers that omit `deploymentId` get identical behavior to the previous version. No breaking changes.

## Test plan

- [ ] `get-deployments` returns deployment history for an environment
- [ ] `get-deployments` with `limit` and `statuses` filters works
- [ ] `get-plan-logs` without `deploymentId` returns latest (unchanged behavior)
- [ ] `get-plan-logs` with `deploymentId` returns plan step log for that specific deployment
- [ ] `get-error-analysis` without `deploymentId` returns latest (unchanged behavior)
- [ ] `get-error-analysis` with `deploymentId` attempts deployment-specific analysis
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)