### PR TITLE
Feat: add search-deployments MCP tool

### DIFF
--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -11,6 +11,7 @@ import type { GetCloudResourcesParams } from '../mcp/schemas/get-cloud-resources
 import type { GetPlanLogsParams } from '../mcp/schemas/get-plan-logs-params-schema';
 import type { GenerateIaCParams } from '../mcp/schemas/generate-iac-schema';
 import type { CheckIaCJobStatusParams } from '../mcp/schemas/check-iac-job-status-schema';
+import type { SearchDeploymentsParams } from '../mcp/schemas/search-deployments-schema';
 
 export class Env0Service {
   private readonly config: Env0Config;
@@ -131,6 +132,22 @@ export class Env0Service {
   async getPlanLogs({ environmentId }: GetPlanLogsParams): Promise<object> {
     return this.env0Client.request({
       url: `/mcp/environments/${environmentId}/plan/logs`
+    });
+  }
+
+  async searchDeployments({
+    environmentId,
+    statuses,
+    limit,
+    offset
+  }: SearchDeploymentsParams): Promise<object> {
+    return this.env0Client.request({
+      url: `/mcp/environments/${environmentId}/deployments`,
+      params: {
+        statuses: statuses || undefined,
+        limit: limit || undefined,
+        offset: offset ?? undefined
+      }
     });
   }
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerGetCloudConfigurationsTool } from './tools/get-cloud-configurations';
 import { registerGetEnvironmentsTool } from './tools/get-environments';
+import { registerSearchDeploymentsTool } from './tools/search-deployments';
 import { Env0Service } from '../env0-service/env0-service';
 import { registerGetProjectsTool } from './tools/get-projects';
 import { registerApproveEnvironmentTool } from './tools/approve-environment';
@@ -31,6 +32,7 @@ export function createMcpServer(env0Service: Env0Service): McpServer {
   registerDeployEnvironmentTool(server, env0Service);
   registerGetPlanLogsTool(server, env0Service);
   registerGetErrorAnalysisTool(server, env0Service);
+  registerSearchDeploymentsTool(server, env0Service);
 
   return server;
 }

--- a/src/mcp/schemas/search-deployments-schema.ts
+++ b/src/mcp/schemas/search-deployments-schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const SearchDeploymentsParamsSchema = z.object({
+  environmentId: z.string().describe('The ID of the environment to list deployments for'),
+  statuses: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated deployment statuses to filter by. Common values: SUCCESS, FAILURE, IN_PROGRESS, CANCELLED, ABORTED, WAITING_FOR_USER, TIMEOUT.'
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(25)
+    .optional()
+    .describe('Maximum number of deployments to return. Defaults to 10, max 25.'),
+  offset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      'Number of deployments to skip from the start (newest-first). Use sparingly — prefer filtering via `statuses` first. Helpful only when you need to dig past the most recent page.'
+    )
+});
+
+export type SearchDeploymentsParams = z.infer<typeof SearchDeploymentsParamsSchema>;

--- a/src/mcp/tools/search-deployments.ts
+++ b/src/mcp/tools/search-deployments.ts
@@ -14,9 +14,12 @@ or needs to pick among multiple recent deployments.
 Do NOT use for the latest deployment alone — get-plan-logs or get-error-analysis
 already cover that without needing an ID.
 
-Returns up to 10 deployments by default (raise limit to 25 max). Each entry
-includes id, status, type, timestamps, trigger, comment, resourceCount,
-blueprintRevision.`;
+Returns up to 10 deployments by default (raise limit to 25 max). Sorted newest-first.
+Each entry includes: id, status, type, queuedAt, startedAt, finishedAt, triggerName,
+comment, resourceCount, blueprintRevision, blueprintName, blueprintType, prNumber,
+gitMetadata, planSummary, failedCommand. Set hasMore=true means another page exists.
+
+Prefer filtering via 'statuses' over paging with 'offset'.`;
 
 export function registerSearchDeploymentsTool(server: McpServer, env0Service: Env0Service): void {
   server.registerTool(

--- a/src/mcp/tools/search-deployments.ts
+++ b/src/mcp/tools/search-deployments.ts
@@ -1,0 +1,53 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Env0Service } from '../../env0-service/env0-service';
+import {
+  type SearchDeploymentsParams,
+  SearchDeploymentsParamsSchema
+} from '../schemas/search-deployments-schema';
+
+const DESCRIPTION = `Find recent deployments for an environment, optionally filtered by status.
+Use this to pick a deploymentLogId for follow-up debug via get-deployment-context.
+
+Use when: user asks for deployment history, wants to find a failed deployment,
+or needs to pick among multiple recent deployments.
+
+Do NOT use for the latest deployment alone — get-plan-logs or get-error-analysis
+already cover that without needing an ID.
+
+Returns up to 10 deployments by default (raise limit to 25 max). Each entry
+includes id, status, type, timestamps, trigger, comment, resourceCount,
+blueprintRevision.`;
+
+export function registerSearchDeploymentsTool(server: McpServer, env0Service: Env0Service): void {
+  server.registerTool(
+    'search-deployments',
+    {
+      title: 'Search Deployments',
+      description: DESCRIPTION,
+      inputSchema: SearchDeploymentsParamsSchema.shape
+    },
+    async (params: SearchDeploymentsParams) => {
+      try {
+        const result = await env0Service.searchDeployments(params);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result)
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching deployments: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new `search-deployments` MCP tool that lists recent deployments for an environment, used to discover a `deploymentLogId` for historical debug flows (paired with the upcoming `get-deployment-context` tool).

## What

`search-deployments(environmentId, statuses?, limit?, offset?)`

- `environmentId` required
- `statuses` comma-separated filter (`SUCCESS,FAILURE,IN_PROGRESS,...`)
- `limit` default 10, max 25
- `offset` for digging past the first page (LLMs are steered to use `statuses` first)

Response = slim allowlisted projection of the deployment log (15 fields) + `hasMore` boolean. No `total`/`offset` returned — LLMs don't paginate past page 1 in the common case.

## Test plan

- [x] Built + lint clean (`npm run build`, `npm run lint`)
- [x] Backend unit tests pass (16/16)
- [x] End-to-end smoke against a backend stage via local MCP server stdio: `tools/list` returns the new tool with full schema; `tools/call search-deployments` returns slim response with all 15 allowlisted fields.
- [x] LLM tool-use evaluation against the backend stage (see breakdown below)

## LLM evaluation breakdown

Real-LLM eval via `claude -p` with the MCP server registered. 8 prompts covering tool selection, param shaping, response interpretation, and error handling. All passed.

| # | Prompt | Expected primary tool | Actual tool call(s) | Notes |
|---|---|---|---|---|
| A1 | "Show me the last 5 deployments of env X" | `search-deployments(limit:5)` | ✓ exact | 2 turns |
| A2 | "Were there any failed deploys on env X?" | `search-deployments(statuses:"FAILURE")` | ✓ exact | 2 turns |
| A3 | "What's the plan output for the latest deployment on env X?" | `get-plan-logs` (NOT search) | ✓ `get-plan-logs` only | tool selection disambiguation working |
| A4 | "Why did env X fail in its last deployment?" | `get-error-analysis` | `get-error-analysis` + `search-deployments` + `get-plan-logs` | LLM chained for richer context — acceptable |
| B1 | "Show me deployments that succeeded or failed" | `statuses:"SUCCESS,FAILURE"` | ✓ exact CSV | param shape correct |
| B2 | "List 100 deployments" | clamp to 25 | paginated 4× (offset 0/25/50/75) | LLM honored user's stated count via pagination — fine |
| C1 | "Summarize the most recent deployment" | `search-deployments(limit:1)` | ✓ exact | summarized blueprint, status, plan, duration |
| E1 | "Show me deployments for env 00000000-…" | tool 404 → LLM relays | ✓ single call, reported "404. Env ID not exist or no access." no retry | graceful failure |