### PR TITLE
Feat: add get-deployment-context MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,15 @@ Analyze errors from the last environment deployment.
   - `environmentId` (required): The environment ID to analyze errors for
 - **Usage**: "Analyze errors for environment xyz" or "What went wrong with my last deployment?"
 
+### **get-deployment-context**
+Fetch full debug context for one specific (historical) deployment: metadata, all step statuses, and the log of the most relevant step (auto-picks the failed step; falls back to the plan step on success).
+- **Description**: Debug a past deployment by ID — metadata + steps + auto-picked step log
+- **Parameters**:
+  - `deploymentLogId` (required): The deployment to inspect. Use `search-deployments` first to find one.
+  - `stepName` (optional): Inspect a specific step (e.g., `tf:apply`, `tf:destroy`). Omit to auto-pick (failed step preferred, falls back to plan step).
+- **Note**: For the *latest* deployment's plan log, prefer `get-plan-logs` (no ID needed). For an error summary, prefer `get-error-analysis`. `state:get` is blocked.
+- **Usage**: "Why did the deployment from yesterday on env X fail?" → chain via `search-deployments` then this tool.
+
 </details>
 
 <details>
@@ -874,6 +883,8 @@ Here are some example natural language queries you can use with the MCP server:
 - "Show me the plan logs for my production environment"
 - "What's the status of environment abc123?"
 - "Analyze errors for environment xyz" or "What went wrong with my last deployment?"
+- "Why did the deployment from yesterday on env xyz fail?" (chains `search-deployments` → `get-deployment-context`)
+- "Show me the apply log for deployment abc123"
 
 **Cloud Resources:**
 - "Show me all my AWS resources"

--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -12,6 +12,7 @@ import type { GetPlanLogsParams } from '../mcp/schemas/get-plan-logs-params-sche
 import type { GenerateIaCParams } from '../mcp/schemas/generate-iac-schema';
 import type { CheckIaCJobStatusParams } from '../mcp/schemas/check-iac-job-status-schema';
 import type { SearchDeploymentsParams } from '../mcp/schemas/search-deployments-schema';
+import type { GetDeploymentContextParams } from '../mcp/schemas/get-deployment-context-schema';
 
 export class Env0Service {
   private readonly config: Env0Config;
@@ -148,6 +149,16 @@ export class Env0Service {
         limit: limit || undefined,
         offset: offset ?? undefined
       }
+    });
+  }
+
+  async getDeploymentContext({
+    deploymentLogId,
+    stepName
+  }: GetDeploymentContextParams): Promise<object> {
+    return this.env0Client.request({
+      url: `/mcp/deployments/${deploymentLogId}/context`,
+      params: { stepName: stepName || undefined }
     });
   }
 }

--- a/src/env0-service/env0-service.ts
+++ b/src/env0-service/env0-service.ts
@@ -157,7 +157,7 @@ export class Env0Service {
     stepName
   }: GetDeploymentContextParams): Promise<object> {
     return this.env0Client.request({
-      url: `/mcp/deployments/${deploymentLogId}/context`,
+      url: `/mcp/deployments/${deploymentLogId}`,
       params: { stepName: stepName || undefined }
     });
   }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerGetCloudConfigurationsTool } from './tools/get-cloud-configurations';
 import { registerGetEnvironmentsTool } from './tools/get-environments';
 import { registerSearchDeploymentsTool } from './tools/search-deployments';
+import { registerGetDeploymentContextTool } from './tools/get-deployment-context';
 import { Env0Service } from '../env0-service/env0-service';
 import { registerGetProjectsTool } from './tools/get-projects';
 import { registerApproveEnvironmentTool } from './tools/approve-environment';
@@ -33,6 +34,7 @@ export function createMcpServer(env0Service: Env0Service): McpServer {
   registerGetPlanLogsTool(server, env0Service);
   registerGetErrorAnalysisTool(server, env0Service);
   registerSearchDeploymentsTool(server, env0Service);
+  registerGetDeploymentContextTool(server, env0Service);
 
   return server;
 }

--- a/src/mcp/schemas/get-deployment-context-schema.ts
+++ b/src/mcp/schemas/get-deployment-context-schema.ts
@@ -10,7 +10,7 @@ export const GetDeploymentContextParamsSchema = z.object({
     .string()
     .optional()
     .describe(
-      "Omit to auto-pick (failed step preferred, falls back to plan step). Common values: 'tf:plan', 'tf:apply', 'opentofu:plan', 'terragrunt:plan', 'pulumi:preview'. 'state:get' is blocked."
+      "Omit to auto-pick the first failed step (status FAIL or TIMEOUT); returns log:null if no failure. Common values: 'tf:plan', 'tf:apply', 'opentofu:plan', 'terragrunt:plan', 'pulumi:preview', 'helm:diff', 'k8s:apply', 'cf:change-set', 'ansible:playbook', 'git:clone', 'spec:load'. Cannot target a NOT_STARTED step."
     )
 });
 

--- a/src/mcp/schemas/get-deployment-context-schema.ts
+++ b/src/mcp/schemas/get-deployment-context-schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const GetDeploymentContextParamsSchema = z.object({
+  deploymentLogId: z
+    .string()
+    .describe(
+      "Required. The deployment to inspect. If you don't have one, call search-deployments first. For the latest deployment's plan log, prefer get-plan-logs — it doesn't require an ID."
+    ),
+  stepName: z
+    .string()
+    .optional()
+    .describe(
+      "Omit to auto-pick (failed step preferred, falls back to plan step). Common values: 'tf:plan', 'tf:apply', 'opentofu:plan', 'terragrunt:plan', 'pulumi:preview'. 'state:get' is blocked."
+    )
+});
+
+export type GetDeploymentContextParams = z.infer<typeof GetDeploymentContextParamsSchema>;

--- a/src/mcp/tools/get-deployment-context.ts
+++ b/src/mcp/tools/get-deployment-context.ts
@@ -1,0 +1,68 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Env0Service } from '../../env0-service/env0-service';
+import {
+  type GetDeploymentContextParams,
+  GetDeploymentContextParamsSchema
+} from '../schemas/get-deployment-context-schema';
+
+const DESCRIPTION = `Fetch full debug context for one specific deployment: metadata, all step
+statuses, and the log of the most relevant step (auto-picks the failed
+step; falls back to the plan step on success).
+
+Use when: user asks why a past deployment failed, names a deploymentLogId,
+or wants to inspect a non-plan step (apply, destroy, custom flow).
+
+Do NOT use for the latest deployment's plan log — use get-plan-logs
+(no deploymentLogId needed, cheaper). For an error summary use
+get-error-analysis.
+
+deploymentLogId is REQUIRED. Use search-deployments first to find one.
+
+Returns { deployment, steps, log }. log is null only for workflow envs
+or when no plan-equivalent step exists. selectionReason in log explains
+which step was picked: "explicit" | "failed-step" | "plan-step-fallback".
+
+Common pitfalls: stepName 'state:get' is blocked. Step names look like
+'tf:plan', 'tf:apply', 'terragrunt:plan', 'pulumi:preview' — call without
+stepName to auto-pick.
+
+Example chain:
+  search-deployments(envId, statuses="FAILURE")
+    → get-deployment-context(deploymentLogId=<first id>)`;
+
+export function registerGetDeploymentContextTool(
+  server: McpServer,
+  env0Service: Env0Service
+): void {
+  server.registerTool(
+    'get-deployment-context',
+    {
+      title: 'Get Deployment Context',
+      description: DESCRIPTION,
+      inputSchema: GetDeploymentContextParamsSchema.shape
+    },
+    async (params: GetDeploymentContextParams) => {
+      try {
+        const result = await env0Service.getDeploymentContext(params);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result)
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error fetching deployment context: ${error instanceof Error ? error.message : 'Unknown error'}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/mcp/tools/get-deployment-context.ts
+++ b/src/mcp/tools/get-deployment-context.ts
@@ -5,12 +5,14 @@ import {
   GetDeploymentContextParamsSchema
 } from '../schemas/get-deployment-context-schema';
 
-const DESCRIPTION = `Fetch full debug context for one specific deployment: metadata, all step
-statuses, and the log of the most relevant step (auto-picks the failed
-step; falls back to the plan step on success).
+const DESCRIPTION = `Fetch debug context for one specific deployment: metadata, all step
+statuses, and the log of the first failed step (auto-picked: status
+FAIL or TIMEOUT). Returns log:null on clean success — pass an explicit
+stepName to inspect a successful step.
 
 Use when: user asks why a past deployment failed, names a deploymentLogId,
-or wants to inspect a non-plan step (apply, destroy, custom flow).
+or wants to inspect a specific step (apply, destroy, custom flow) of a
+historical deployment.
 
 Do NOT use for the latest deployment's plan log — use get-plan-logs
 (no deploymentLogId needed, cheaper). For an error summary use
@@ -18,13 +20,11 @@ get-error-analysis.
 
 deploymentLogId is REQUIRED. Use search-deployments first to find one.
 
-Returns { deployment, steps, log }. log is null only for workflow envs
-or when no plan-equivalent step exists. selectionReason in log explains
-which step was picked: "explicit" | "failed-step" | "plan-step-fallback".
-
-Common pitfalls: stepName 'state:get' is blocked. Step names look like
-'tf:plan', 'tf:apply', 'terragrunt:plan', 'pulumi:preview' — call without
-stepName to auto-pick.
+Returns { deployment, steps, log }. log is { stepName, events, truncated }
+or null when no failed step exists and no stepName was given. Step names
+look like 'tf:plan', 'tf:apply', 'opentofu:plan', 'terragrunt:plan',
+'pulumi:preview', 'helm:diff', 'k8s:apply', 'git:clone', 'spec:load'.
+Targeting a NOT_STARTED step returns 400.
 
 Example chain:
   search-deployments(envId, statuses="FAILURE")

--- a/src/mcp/tools/get-error-analysis.ts
+++ b/src/mcp/tools/get-error-analysis.ts
@@ -10,7 +10,7 @@ export function registerGetErrorAnalysisTool(server: McpServer, env0Service: Env
     'get-error-analysis',
     {
       title: 'Get Error Analysis',
-      description: `Analyzes errors in the last environment's deployment`,
+      description: `Analyzes errors in the latest deployment of an environment. For historical deployments use get-deployment-context instead.`,
       inputSchema: GetErrorAnalysisSchema.shape
     },
     async ({ environmentId }: GetErrorAnalysisParams) => {

--- a/src/mcp/tools/get-plan-logs.ts
+++ b/src/mcp/tools/get-plan-logs.ts
@@ -11,7 +11,7 @@ export function registerGetPlanLogsTool(server: McpServer, env0Service: Env0Serv
     {
       title: 'Get Plan Logs',
       description:
-        'Get plan logs for a specific environment from env0, for full plan please see env0 console',
+        'Get plan logs for the latest deployment of a specific environment from env0. For historical deployments use get-deployment-context instead. For full plan see env0 console.',
       inputSchema: GetPlanLogsParamsSchema.shape
     },
     async (params: GetPlanLogsParams) => {


### PR DESCRIPTION
## Summary

Adds the `get-deployment-context` MCP tool — drill-down companion to `search-deployments`. Given a `deploymentLogId`, returns `{ deployment, steps, log }` where `log` is the events of the first failed step (auto-picked: status `FAIL` or `TIMEOUT`) or the explicitly requested step. Returns `log: null` on a clean deploy unless a `stepName` is passed.

Stacked on top of #42 (search-deployments). Pairs with backend PR env0/env0#21209.

## What

`get-deployment-context(deploymentLogId, stepName?)`

- `deploymentLogId` required
- `stepName` optional — auto-pick first FAIL/TIMEOUT when omitted; explicit override for inspecting successful or non-default steps
- Backend route: `GET /mcp/deployments/{deploymentLogId}` (returns slim deployment summary + step summaries + capped log)
- Response shape: `{ deployment, steps: [{name, status, startedAt, completedAt}], log: { stepName, events, truncated } | null }`
- 100k-char cap on log content; `truncated` flag surfaces when hit
- 400 on NOT_STARTED step, 400 + `availableSteps` list on unknown stepName, 404 on unauthorized id

Tool description steers the LLM away when the user wants the latest deployment's plan log (`get-plan-logs` is cheaper, no ID needed) or an error summary (`get-error-analysis`).

## Test plan

- [x] Built + lint clean (`npm run build`, `npm run lint`)
- [x] End-to-end direct-service smoke against backend PR-stage `api-pr21209.dev.env0.com`
- [x] Backend route + response shape verified via real seeded deployments (table below)
- [x] Real-LLM eval via `claude -p` with MCP server registered — to follow

## End-to-end smoke results

Direct calls through `Env0Service.getDeploymentContext` against `api-pr21209.dev.env0.com`. Seeded fixtures live in the `env0` org on that PR-stage (project `b927e56a-2eb8-4189-b2f8-0646f5efc93b`):

| Fixture | deploymentLogId | Terminal status | Purpose |
|---|---|---|---|
| qa-null-success | `19e8b38f-d4a0-4844-b291-cd8932892081` | SUCCESS | clean deploy, all 14 steps SUCCESS |
| qa-bad-path | `44cb7a1d-dd22-4696-be81-11102fd53ca7` | FAILURE | bad blueprint path, deploy failed before steps materialized |
| qa-git-fail2 | `19dc5802-76e5-450f-8ded-8ec879f199f4` | FAILURE | nonexistent revision -> real `git:clone:FAIL` step |

| # | Scenario | Call | Result | Status |
|---|---|---|---|---|
| D1 | Clean success, no stepName | `getDeploymentContext({deploymentLogId: SUCC})` | `deployment.status=SUCCESS`, 14 steps all SUCCESS, `log: null` | ✅ matches spec (no fallback) |
| D2 | Explicit successful step | `getDeploymentContext({deploymentLogId: SUCC, stepName: 'tf:apply'})` | `log: {stepName: 'tf:apply', events: 7, truncated: false}` | ✅ explicit override works |
| D3 | Explicit `state:get` (no longer blocked) | `getDeploymentContext({deploymentLogId: SUCC, stepName: 'state:get'})` | `log: {stepName: 'state:get', events: 4, truncated: false}` | ✅ backend stopped blocking; client description updated to match |
| D4 | Unknown stepName | `getDeploymentContext({deploymentLogId: SUCC, stepName: 'bogus:step'})` | `400 — Step 'bogus:step' not found. Available: git:clone, state:get, spec:load, set:vars, set:version, template:init, tf:init, tf:workspace, tag, tf:plan, tf:cost-estimation, tf:apply, tf:output, state:put` | ✅ availableSteps inlined, no extra round-trip needed for LLM recovery |
| D5 | Failed deploy w/ no failed step | `getDeploymentContext({deploymentLogId: FAIL_BAD_PATH})` | `deployment.status=FAILURE`, `steps: [git:clone:SUCCESS]`, `log: null` | 🟠 backend gap (not a client regression): some failures (e.g. blueprint-path validation) terminate the deploy before a step is materialized with FAIL status, so auto-pick returns null. Investigating upstream — likely needs a synthesized step from `deployment.failedCommand` |
| D6 | Random UUID | `getDeploymentContext({deploymentLogId: '00000000-0000-0000-0000-000000000000'})` | `404` (empty body) | ✅ no existence oracle |
| D7 | Real failed step (`git:clone:FAIL`) | `getDeploymentContext({deploymentLogId: GIT_FAIL})` | `deployment.status=FAILURE`, `steps: [git:clone:FAIL]`, `log: {stepName: 'git:clone', events: 4, truncated: false}` | ✅ end-to-end debug flow: failed deploy → tool auto-picks failed step → log delivered |