### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@env0/mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@env0/mcp-server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@env0/mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
Release version bump for v1.1.0 — adds the search-deployments and get-deployment-context MCP tools.